### PR TITLE
Enable for javascriptnext syntax

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class GJSLint(Linter):
 
     """Provides an interface to the gjslint executable."""
 
-    syntax = ('javascript', 'html')
+    syntax = ('javascript', 'javascriptnext', 'html')
     cmd = 'gjslint --nobeep --nosummary'
     regex = r'^Line (?P<line>\d+), (?:(?P<error>E)|(?P<warning>W)):\d+: (?P<message>[^"]+(?P<near>"[^"]+")?.*$)'
     comment_re = r'\s*/[/*]'


### PR DESCRIPTION
This syntax becoming quite popular, no reason to not to run linter
in it as it seems to support classes and other ES6 syntax quite well.