### PR TITLE
fix #10 remove argument settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@ The docs cover [troubleshooting PATH configuration](http://sublimelinter.com/en/
 - SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html
 - Linter settings: http://sublimelinter.com/en/latest/linter_settings.html
 
-Additional SublimeLinter-gjslint settings: 
-
-|Setting        |Description|
-|:--------------|:----------|
-|jslint_error   |A comma-separated list of specific lint errors to check|
-|disable        |A comma-separated list of error codes to ignore|
-|max_line_length|The maximum allowed line length. `null` allows any length.|
-
 We recommend configuring options in a .gjslintrc file (the linter will search for a config file with that name in your project path or ancestors). This is an example of a .gjslintrc file:
 
 ```

--- a/linter.py
+++ b/linter.py
@@ -5,9 +5,6 @@ class GJSLint(Linter):
     cmd = 'gjslint --nobeep --nosummary'
     regex = r'^Line (?P<line>\d+), (?:(?P<error>E)|(?P<warning>W)):\d+: (?P<message>[^"]+(?P<near>"[^"]+")?.*$)'
     defaults = {
-        'selector': 'source.js - meta.attribute-with-value',
-        '--jslint_error:,+': '',
-        '--disable:,': '',
-        '--max_line_length:': None
+        'selector': 'source.js - meta.attribute-with-value'
     }
     tempfile_suffix = 'js'

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,4 @@
 {
-    "install": "messages/install.txt"
+    "install": "messages/install.txt",
+    "install": "messages/1.2.0.txt"
 }

--- a/messages/1.2.0.txt
+++ b/messages/1.2.0.txt
@@ -1,0 +1,7 @@
+SublimeLinter-gjslint 1.2.0
+-------------------------------
+
+The settings to pass arguments like `disable` and `max_line_length` to
+gjslint have been removed. You can use the "args" setting to pass any
+argument you like:
+http://www.sublimelinter.com/en/latest/linter_settings.html#args


### PR DESCRIPTION
Removes settings like `--disable` and `--max_line_length` which are simply arguments for the linter. The settings confuse people, and there is a perfectly functional `args` setting already in core.

@kaste agree?

Also, gjslint has been deprecated quite a while ago, best spend as little effort here as possible.